### PR TITLE
Allow comments in txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ Run `plex-poster-set-helper.py`
 ## Modes
 **Bulk Import**
 
-     1. Enter 'bulk' in the first input prompt
-     2. Enter the path to a .txt file with multiple links (on separate lines)
+1. Enter `bulk` in the first input prompt
+2. Enter the path to a .txt file with multiple links (on separate lines)

--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ pip install -r requirements.txt
 
 Run `plex-poster-set-helper.py`
 
+## Modes
+**Bulk Import**
+
+     1. Enter 'bulk' in the first input prompt
+     2. Enter the path to a .txt file with multiple links (on separate lines)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # plex-poster-set-helper
 
-plex-poster=set-helper is a tool to help upload sets of posters from ThePosterDB or MediUX to your Plex server in seconds!
+plex-poster-set-helper is a tool to help upload sets of posters from ThePosterDB or MediUX to your Plex server in seconds!
 
 ## Installation
 

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -330,10 +330,20 @@ if __name__ == "__main__":
     tv, movies = plex_setup()
     
     while True:
-        user_input = input("Enter a ThePosterDB set (or user) or a MediUX set url (type 'stop' to end): ")
+        user_input = input("Enter a ThePosterDB set (or user) or a MediUX set url: ")
         
         if user_input.lower() == 'stop':
             print("Stopping...")
             break
-
-        set_posters(user_input, tv, movies)
+        elif user_input.lower() == 'bulk':
+            file_path = input("Enter the path to the .txt file: ")
+            try:
+                with open(file_path, 'r') as file:
+                    urls = file.readlines()
+                for url in urls:
+                    url = url.strip()
+                    set_posters(url, tv, movies)
+            except FileNotFoundError:
+                print("File not found. Please enter a valid file path.")
+        else:
+            set_posters(user_input, tv, movies)

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -85,7 +85,7 @@ def parse_string_to_dict(input_string):
     json_start_index = input_string.find('{')
     json_end_index = input_string.rfind('}')
     json_data = input_string[json_start_index:json_end_index+1]
-
+    
     parsed_dict = json.loads(json_data)
     return parsed_dict
 
@@ -124,26 +124,26 @@ def upload_tv_poster(poster, tv):
         try:
             if poster["season"] == "Cover":
                 upload_target = tv_show
-                print(f"Uploaded cover art for {poster['title']} - {poster['season']}.")
+                print("Uploaded cover art for {} - {}.".format(poster['title'], poster['season']))
             elif poster["season"] == 0:
                 upload_target = tv_show.season("Specials")
-                print(f"Uploaded art for {poster['title']} - Specials.")
+                print("Uploaded art for {} - Specials.".format(poster['title']))
             elif poster["season"] == "Backdrop":
                 upload_target = tv_show
-                print(f"Uploaded background art for {poster['title']}.")
+                print("Uploaded background art for {}.".format(poster['title']))
             elif poster["season"] >= 1:
                 if poster["episode"] == "Cover":
                     upload_target = tv_show.season(poster["season"])
-                    print(f"Uploaded art for {poster['title']} - Season {poster['season']}.")
+                    print("Uploaded art for {} - Season {}.".format(poster['title'], poster['season']))
                 elif poster["episode"] is None:
                     upload_target = tv_show.season(poster["season"])
-                    print(f"Uploaded art for {poster['title']} - Season {poster['season']}.")
+                    print("Uploaded art for {} - Season {}.".format(poster['title'], poster['season']))
                 elif poster["episode"] is not None:
                     try:
                         upload_target = tv_show.season(poster["season"]).episode(poster["episode"])
-                        print(f"Uploaded art for {poster['title']} - Season {poster['season']} Episode {poster['episode']}.")
+                        print("Uploaded art for {} - Season {} Episode {}.".format(poster['title'], poster['season'], poster['episode']))
                     except:
-                        print(f"{poster['title']} - {poster['season']} Episode {poster['episode']} not found, skipping.")
+                        print("{} - Season {} Episode {} not found, skipping.".format(poster['title'], poster['season'], poster['episode']))
             if poster["season"] == "Backdrop":
                 upload_target.uploadArt(url=poster['url'])
             else:

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -85,10 +85,18 @@ def parse_string_to_dict(input_string):
 
     json_start_index = input_string.find('{')
     json_end_index = input_string.rfind('}')
-    json_data = input_string[json_start_index:json_end_index+1]
-
-    parsed_dict = json.loads(json_data)
-    return parsed_dict
+    
+    if json_start_index != -1 and json_end_index != -1:
+        json_data = input_string[json_start_index:json_end_index+1]
+        try:
+            parsed_dict = json.loads(json_data)
+            return parsed_dict
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON: {e}")
+            return None
+    else:
+        print("No JSON data found.")
+        return None
 
 
 def find_in_library(library, poster):

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -25,17 +25,21 @@ def plex_setup():
             sys.exit('Unable to connect to Plex server. Please check the "base_url" in config.json, and consult the readme.md.')
         except plexapi.exceptions.Unauthorized:
             sys.exit('Invalid Plex token. Please check the "token" in config.json, and consult the readme.md.')
+        if isinstance(tv_library, str):
+            tv_library = [tv_library] 
+        elif not isinstance(tv_library, list):
+            sys.exit("tv_library must be either a string or a list")
         tv = []
         for tv_lib in tv_library:
             try:
                 plex_tv = plex.library.section(tv_lib)
                 tv += plex_tv.all()
             except plexapi.exceptions.NotFound:
-                sys.exit(f'TV library named "{tv_library}" not found. Please check the "tv_library" in config.json, and consult the readme.md.')        
-            try:
-                movies = plex.library.section(movie_library)        
-            except plexapi.exceptions.NotFound:
-                sys.exit(f'Movie library named "{movie_library}" not found. Please check the "movie_library" in config.json, and consult the readme.md.')
+                sys.exit(f'TV library named "{tv_lib}" not found. Please check the "tv_library" in config.json, and consult the readme.md.')        
+        try:
+            movies = plex.library.section(movie_library)        
+        except plexapi.exceptions.NotFound:
+            sys.exit(f'Movie library named "{movie_library}" not found. Please check the "movie_library" in config.json, and consult the readme.md.')
         return tv, movies
     else:
         sys.exit("No config.json file found. Please consult the readme.md.")   

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -16,7 +16,7 @@ def plex_setup():
             base_url = config["base_url"]
             token = config["token"]
             tv_library = config["tv_library"]
-            movie_library = config["movie_library"]    
+            movie_library = config["movie_library"]
         except:
             sys.exit("Error with config.json file. Please consult the readme.md.") 
         try:
@@ -25,17 +25,20 @@ def plex_setup():
             sys.exit('Unable to connect to Plex server. Please check the "base_url" in config.json, and consult the readme.md.')
         except plexapi.exceptions.Unauthorized:
             sys.exit('Invalid Plex token. Please check the "token" in config.json, and consult the readme.md.')
-        try:
-            tv = plex.library.section(tv_library)
-        except plexapi.exceptions.NotFound:
-            sys.exit(f'TV library named "{tv_library}" not found. Please check the "tv_library" in config.json, and consult the readme.md.')
-        try:
-            movies = plex.library.section(movie_library)
-        except:
-            sys.exit(f'Movie library named "{movie_library}" not found. Please check the "movie_library" in config.json, and consult the readme.md.')
+        tv = []
+        for tv_lib in tv_library:
+            try:
+                plex_tv = plex.library.section(tv_lib)
+                tv += plex_tv.all()
+            except plexapi.exceptions.NotFound:
+                sys.exit(f'TV library named "{tv_library}" not found. Please check the "tv_library" in config.json, and consult the readme.md.')        
+            try:
+                movies = plex.library.section(movie_library)        
+            except plexapi.exceptions.NotFound:
+                sys.exit(f'Movie library named "{movie_library}" not found. Please check the "movie_library" in config.json, and consult the readme.md.')
         return tv, movies
     else:
-        sys.exit("No config.json file found. Please consult the readme.md.")    
+        sys.exit("No config.json file found. Please consult the readme.md.")   
 
 
 def cook_soup(url):  
@@ -77,9 +80,15 @@ def parse_string_to_dict(input_string):
     return parsed_dict
 
 
+def find_in_library(library, poster):
+    for media in library:
+        if media.title == poster["title"]:
+            return media
+    raise ValueError("Object with title '{}' not found".format(poster["title"]))
+
 def upload_tv_poster(poster, tv):
     try:
-        tv_show = tv.get(poster["title"])
+        tv_show = find_in_library(tv, poster)
         try:
             if poster["season"] == "Cover":
                 upload_target = tv_show

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -388,19 +388,6 @@ def scrape(url):
         sys.exit("Poster set not found. Check the link you are inputting.")  
 
 
-
-def is_valid_url(url):
-    # Regular expression to check if the URL is valid
-    regex = r"^(http|https):\/\/[^\/]+\/sets\/\d+\/?$"
-    # Compile the regex pattern
-    pattern = re.compile(regex)
-    # Check if the URL matches the pattern
-    if re.match(pattern, url):
-        return True
-    else:
-        return False
-
-
 if __name__ == "__main__":
     tv, movies = plex_setup()
     
@@ -414,8 +401,7 @@ if __name__ == "__main__":
                         urls = file.readlines()
                     for url in urls:
                         url = url.strip()
-                        if is_valid_url(url):
-                            set_posters(url, tv, movies)
+                        set_posters(url, tv, movies)
                 except FileNotFoundError:
                     print("File not found. Please enter a valid file path.")
             else:
@@ -436,8 +422,7 @@ if __name__ == "__main__":
                         urls = file.readlines()
                     for url in urls:
                         url = url.strip()
-                        if is_valid_url(url):
-                            set_posters(url, tv, movies)
+                        set_posters(url, tv, movies)
                 except FileNotFoundError:
                     print("File not found. Please enter a valid file path.")
             else:

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -85,7 +85,7 @@ def parse_string_to_dict(input_string):
     json_start_index = input_string.find('{')
     json_end_index = input_string.rfind('}')
     json_data = input_string[json_start_index:json_end_index+1]
-    
+
     parsed_dict = json.loads(json_data)
     return parsed_dict
 
@@ -124,26 +124,26 @@ def upload_tv_poster(poster, tv):
         try:
             if poster["season"] == "Cover":
                 upload_target = tv_show
-                print("Uploaded cover art for {} - {}.".format(poster['title'], poster['season']))
+                print(f"Uploaded cover art for {poster['title']} - {poster['season']}.")
             elif poster["season"] == 0:
                 upload_target = tv_show.season("Specials")
-                print("Uploaded art for {} - Specials.".format(poster['title']))
+                print(f"Uploaded art for {poster['title']} - Specials.")
             elif poster["season"] == "Backdrop":
                 upload_target = tv_show
-                print("Uploaded background art for {}.".format(poster['title']))
+                print(f"Uploaded background art for {poster['title']}.")
             elif poster["season"] >= 1:
                 if poster["episode"] == "Cover":
                     upload_target = tv_show.season(poster["season"])
-                    print("Uploaded art for {} - Season {}.".format(poster['title'], poster['season']))
+                    print(f"Uploaded art for {poster['title']} - Season {poster['season']}.")
                 elif poster["episode"] is None:
                     upload_target = tv_show.season(poster["season"])
-                    print("Uploaded art for {} - Season {}.".format(poster['title'], poster['season']))
+                    print(f"Uploaded art for {poster['title']} - Season {poster['season']}.")
                 elif poster["episode"] is not None:
                     try:
                         upload_target = tv_show.season(poster["season"]).episode(poster["episode"])
-                        print("Uploaded art for {} - Season {} Episode {}.".format(poster['title'], poster['season'], poster['episode']))
+                        print(f"Uploaded art for {poster['title']} - Season {poster['season']} Episode {poster['episode']}.")
                     except:
-                        print("{} - Season {} Episode {} not found, skipping.".format(poster['title'], poster['season'], poster['episode']))
+                        print(f"{poster['title']} - {poster['season']} Episode {poster['episode']} not found, skipping.")
             if poster["season"] == "Backdrop":
                 upload_target.uploadArt(url=poster['url'])
             else:
@@ -274,6 +274,7 @@ def scrape_mediux(soup):
     quality_suffix = "&w=3840&q=80"
     
     scripts = soup.find_all('script')
+    
     
     media_type = None
     showposters = []

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -85,19 +85,10 @@ def parse_string_to_dict(input_string):
 
     json_start_index = input_string.find('{')
     json_end_index = input_string.rfind('}')
+    json_data = input_string[json_start_index:json_end_index+1]
     
-    if json_start_index != -1 and json_end_index != -1:
-        json_data = input_string[json_start_index:json_end_index+1]
-        try:
-            parsed_dict = json.loads(json_data)
-            return parsed_dict
-        except json.JSONDecodeError as e:
-            print(f"Error decoding JSON: {e}")
-            return None
-    else:
-        print("No JSON data found.")
-        return None
-
+    parsed_dict = json.loads(json_data)
+    return parsed_dict
 
 def find_in_library(library, poster):
     for lib in library:

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -126,26 +126,26 @@ def upload_tv_poster(poster, tv):
         try:
             if poster["season"] == "Cover":
                 upload_target = tv_show
-                print(f"Uploaded cover art for {poster['title']} - {poster['season']}.")
+                print("Uploaded cover art for {} - {}.".format(poster['title'], poster['season']))
             elif poster["season"] == 0:
                 upload_target = tv_show.season("Specials")
-                print(f"Uploaded art for {poster['title']} - Specials.")
+                print("Uploaded art for {} - Specials.".format(poster['title']))
             elif poster["season"] == "Backdrop":
                 upload_target = tv_show
-                print(f"Uploaded background art for {poster['title']}.")
+                print("Uploaded background art for {}.".format(poster['title']))
             elif poster["season"] >= 1:
                 if poster["episode"] == "Cover":
                     upload_target = tv_show.season(poster["season"])
-                    print(f"Uploaded art for {poster['title']} - Season {poster['season']}.")
+                    print("Uploaded art for {} - Season {}.".format(poster['title'], poster['season']))
                 elif poster["episode"] is None:
                     upload_target = tv_show.season(poster["season"])
-                    print(f"Uploaded art for {poster['title']} - Season {poster['season']}.")
+                    print("Uploaded art for {} - Season {}.".format(poster['title'], poster['season']))
                 elif poster["episode"] is not None:
                     try:
                         upload_target = tv_show.season(poster["season"]).episode(poster["episode"])
-                        print(f"Uploaded art for {poster['title']} - Season {poster['season']} Episode {poster['episode']}.")
+                        print("Uploaded art for {} - Season {} Episode {}.".format(poster['title'], poster['season'], poster['episode']))
                     except:
-                        print(f"{poster['title']} - {poster['season']} Episode {poster['episode']} not found, skipping.")
+                        print("{} - Season {} Episode {} not found, skipping.".format(poster['title'], poster['season'], poster['episode']))
             if poster["season"] == "Backdrop":
                 upload_target.uploadArt(url=poster['url'])
             else:
@@ -153,7 +153,7 @@ def upload_tv_poster(poster, tv):
             if poster["source"] == "posterdb":
                 time.sleep(6) # too many requests prevention
         except:
-            print(f"{poster['title']} - Season {poster['season']} not found, skipping.")
+            print("{} - Season {} not found, skipping.".format(poster['title'], poster['season']))
 
 
 def upload_movie_poster(poster, movies):
@@ -351,24 +351,57 @@ def scrape(url):
         sys.exit("Poster set not found. Check the link you are inputting.")  
 
 
+
+def is_valid_url(url):
+    # Regular expression to check if the URL is valid
+    regex = r"^(http|https):\/\/[^\/]+\/sets\/\d+\/?$"
+    # Compile the regex pattern
+    pattern = re.compile(regex)
+    # Check if the URL matches the pattern
+    if re.match(pattern, url):
+        return True
+    else:
+        return False
+
+
 if __name__ == "__main__":
     tv, movies = plex_setup()
     
-    while True:
-        user_input = input("Enter a ThePosterDB set (or user) or a MediUX set url: ")
-        
-        if user_input.lower() == 'stop':
-            print("Stopping...")
-            break
-        elif user_input.lower() == 'bulk':
-            file_path = input("Enter the path to the .txt file: ")
-            try:
-                with open(file_path, 'r') as file:
-                    urls = file.readlines()
-                for url in urls:
-                    url = url.strip()
-                    set_posters(url, tv, movies)
-            except FileNotFoundError:
-                print("File not found. Please enter a valid file path.")
+    if len(sys.argv) > 1:
+        command = sys.argv[1]
+        if command.lower() == 'bulk':
+            if len(sys.argv) > 2:
+                file_path = sys.argv[2]
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as file:
+                        urls = file.readlines()
+                    for url in urls:
+                        url = url.strip()
+                        if is_valid_url(url):
+                            set_posters(url, tv, movies)
+                except FileNotFoundError:
+                    print("File not found. Please enter a valid file path.")
+            else:
+                print("Please provide the path to the file.")
         else:
-            set_posters(user_input, tv, movies)
+            set_posters(command, tv, movies)
+    else:
+        while True:
+            user_input = input("Enter a ThePosterDB set (or user) or a MediUX set url: ")
+            
+            if user_input.lower() == 'stop':
+                print("Stopping...")
+                break
+            elif user_input.lower() == 'bulk':
+                file_path = input("Enter the path to the .txt file: ")
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as file:
+                        urls = file.readlines()
+                    for url in urls:
+                        url = url.strip()
+                        if is_valid_url(url):
+                            set_posters(url, tv, movies)
+                except FileNotFoundError:
+                    print("File not found. Please enter a valid file path.")
+            else:
+                set_posters(user_input, tv, movies)

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -275,7 +275,6 @@ def scrape_mediux(soup):
     
     scripts = soup.find_all('script')
     
-
     media_type = None
     showposters = []
     movieposters = []

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -73,8 +73,8 @@ def title_cleaner(string):
 
 
 def parse_string_to_dict(input_string):
-    input_string = input_string.encode('utf-8').decode('unicode_escape')
     input_string = input_string.replace("\\","")
+    input_string = input_string.replace("u0026", "&")
 
     json_start_index = input_string.find('{')
     json_end_index = input_string.rfind('}')

--- a/plex-poster-set-helper.py
+++ b/plex-poster-set-helper.py
@@ -275,7 +275,7 @@ def scrape_mediux(soup):
     
     scripts = soup.find_all('script')
     
-    
+
     media_type = None
     showposters = []
     movieposters = []


### PR DESCRIPTION
Specifically allows lines to start with "//", "#", or to be blank in the txt file provided when the bulk command is used. This allows for cleaner organization of txt files.

![image](https://github.com/bbrown430/plex-poster-set-helper/assets/59670293/09a3cf43-b697-41f2-9cda-cd9d9199fba9)

Here's a test file I created and the input from running it.

![image](https://github.com/bbrown430/plex-poster-set-helper/assets/59670293/48677899-fcf0-4de3-bfda-91889f52fd48)


![image](https://github.com/bbrown430/plex-poster-set-helper/assets/59670293/dcee88e5-cfb1-4002-b33b-d37e30c2be45)
