### PR TITLE
Set stdout encoding to UTF-8 to prevent titles like Shōgun from erroring

### DIFF
--- a/plex_poster_set_helper.py
+++ b/plex_poster_set_helper.py
@@ -447,6 +447,8 @@ def parse_urls(file_path):
 
 
 if __name__ == "__main__":
+    # Set stdout encoding to UTF-8
+    sys.stdout.reconfigure(encoding='utf-8')
     tv, movies = plex_setup()
     
     # arguments were provided


### PR DESCRIPTION
### Description

This update sets the `stdout` encoding to UTF-8, which ensures that titles containing special characters, such as "Shōgun", are printed without causing encoding errors. This change allows the script to handle a wider range of Unicode characters in the output.