### PR TITLE
fix: split from the end to handle case where a show has a word in it beginning with E

### DIFF
--- a/plex_poster_set_helper.py
+++ b/plex_poster_set_helper.py
@@ -440,7 +440,7 @@ def scrape_mediux(soup):
                 season = data["episode_id"]["season_id"]["season_number"]
                 title = data["title"]
                 try:
-                    episode = int(title.split(" E")[1])
+                    episode = int(title.rsplit(" E",1)[1])
                 except:
                     print(f"Error getting episode number for {title}.")
                 file_type = "title_card"


### PR DESCRIPTION
`title.split(" E")[1]` will fail to split the episode number out of `The Expanse (2015) - S0 E79`

I ran into 0 issues running with this change.