### PR TITLE
Configurable Caching Option

### DIFF
--- a/plex_poster_set_helper.py
+++ b/plex_poster_set_helper.py
@@ -334,17 +334,28 @@ def parse_string_to_dict(input_string):
 def find_in_library(library, poster):
     items = []
     for lib in library:
+        library_item = None
         try:
             if poster.year is not None:
-                library_item = lib.get(poster.title, year=poster.year)
+                try:
+                    library_item = lib.get(poster.title, year=poster.year)
+                except:
+                    pass
+                if not library_item and ": " in poster.title: # title might not include a prefix like Star Wars:
+                    library_item = lib.get(poster.title.split(": "[1]))
             else:
-                library_item = lib.get(poster.title)
+                try:
+                    library_item = lib.get(poster.title)
+                except:
+                    pass
+                if not library_item and ": " in poster.title: # title might not include a prefix like Star Wars:
+                    library_item = lib.get(poster.title.split(": "[1]))
             
             if library_item:
                 items.append(library_item)
-        except:
+        except Exception as e:
             pass
-    
+
     if items:
         return items
     
@@ -423,6 +434,9 @@ def upload_tv_poster(poster, url, filepath, tv) -> bool:
                 elif poster.show_backdrop:
                     upload_target = tv_show
                     print(f"Uploaded background art for {poster.title} in {tv_show.librarySectionTitle} library.")
+                elif poster.season is None:
+                    print(f"Unknown media type for {poster.title}: {poster.url}")
+                    continue
                 elif poster.season is not None and poster.season >= 1:
                     if poster.season_cover_art:
                         upload_target = tv_show.season(poster.season)
@@ -433,6 +447,7 @@ def upload_tv_poster(poster, url, filepath, tv) -> bool:
                             print(f"Uploaded art for {poster.title} - Season {poster.season} Episode {poster.episode} in {tv_show.librarySectionTitle} library..")
                         except:
                             print(f"{poster.title} - {poster.season} Episode {poster.episode} not found in {tv_show.librarySectionTitle} library, skipping.")
+                            continue
                 if poster.show_backdrop:
                     try:
                         upload_target.uploadArt(url=url, filepath=filepath)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ urllib3==2.1.0
 customtkinter==5.2.2
 Pillow==10.4.0
 fleep
+pathvalidate

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ soupsieve==2.5
 urllib3==2.1.0
 customtkinter==5.2.2
 Pillow==10.4.0
+fleep


### PR DESCRIPTION
Adds the following optionable configuration parameters. With `cache_enabled=false` the script will function as it currently does. Setting it to true and providing a relative or absolute path in `cache_folder` will turn caching on.
```
"cache_enabled": true,
"cache_folder": "cache"
```

![image](https://github.com/user-attachments/assets/2957f8ad-aea4-45f1-914a-8fee0462edba)

Current logic:
1. For a given mediux or posterdb url we scrape the page as usual.
2. Once we go to upload to plex we check if caching is enabled.
3. If not then upload.
4. If enabled, check the cache for the metadata json file for that item.
5. If that doesn't exist then download into the cache, and upload to plex.
6. If it exists then we check the json to see if we've already upload to plex. If not, then attempt to upload. If so, skip.

I have some cleanup to do and a check for if the json url (mediux or posterdb) has changed. This change significantly brings the runtime down.

Attempt to solve #38 