### PR TITLE
Reduce Year Mismatches

### DIFF
--- a/src/scrapers/base_scraper.py
+++ b/src/scrapers/base_scraper.py
@@ -441,12 +441,7 @@ class BaseScraper(ABC):
                 wait_strategies = ["domcontentloaded", "networkidle"]
                 wait_until = random.choice(wait_strategies)
                 
-                try:
-                    self._page.goto(url, wait_until=wait_until, timeout=120000)
-                except Exception as e:
-                    print(f"Retrying with alternate wait strategy due to error: {str(e)}")
-                    wait_until = wait_strategies[0] if wait_until == wait_strategies[1] else wait_strategies[1]
-                    self._page.goto(url, wait_until=wait_until, timeout=120000)
+                self._page.goto(url, wait_until=wait_until, timeout=60000)
                 
                 # Site-specific handling with configurable delays
                 if "mediux.pro" in url:

--- a/src/scrapers/base_scraper.py
+++ b/src/scrapers/base_scraper.py
@@ -441,7 +441,12 @@ class BaseScraper(ABC):
                 wait_strategies = ["domcontentloaded", "networkidle"]
                 wait_until = random.choice(wait_strategies)
                 
-                self._page.goto(url, wait_until=wait_until, timeout=60000)
+                try:
+                    self._page.goto(url, wait_until=wait_until, timeout=120000)
+                except Exception as e:
+                    print(f"Retrying with alternate wait strategy due to error: {str(e)}")
+                    wait_until = wait_strategies[0] if wait_until == wait_strategies[1] else wait_strategies[1]
+                    self._page.goto(url, wait_until=wait_until, timeout=120000)
                 
                 # Site-specific handling with configurable delays
                 if "mediux.pro" in url:

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -5,23 +5,6 @@ import sys
 import re
 
 
-def title_cleaner(title: str) -> str:
-    """Clean title by removing year and extra information.
-    
-    Args:
-        title: Title string to clean.
-        
-    Returns:
-        Cleaned title string.
-    """
-    if " (" in title:
-        title = title.split(" (")[0]
-    elif " -" in title:
-        title = title.split(" -")[0]
-    
-    return title.strip()
-
-
 def parse_string_to_dict(input_string: str) -> dict:
     """Parse JSON string from HTML content.
     


### PR DESCRIPTION
Adds a check for +- 1 year for a title before attempting to use fuzzy matching. Often times this will find a match due to metadata differences in sites.